### PR TITLE
Use _values attr to access property setter method

### DIFF
--- a/STR/FallVelocity.py
+++ b/STR/FallVelocity.py
@@ -226,9 +226,7 @@ class FallVelocity(Bmi):
         src : int or float
             New value
         """
-        val = self.get_value_ref(var_name)
-        val = float(src)
-
+        self._values[var_name] = float(src)
 
 
     def get_component_name(self):


### PR DESCRIPTION
I think the issue is that this statement

    val = float(src)

clobbers the reference held by `val`, so the property setter method in the model doesn't get called. I've implemented *set_value* slightly differently so that input value gets passed through to the property setter.

Let me know what you think.